### PR TITLE
Fix: Use GOOGLE_API_KEY environment variable for Gemini API tests

### DIFF
--- a/.github/workflows/gemini_test.yml
+++ b/.github/workflows/gemini_test.yml
@@ -28,5 +28,5 @@ jobs:
 
       - name: Test Gemini API
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: python test_gemini_api.py "${{ secrets.GEMINI_API_KEY }}"
+          GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: python test_gemini_api.py

--- a/test_gemini_api.py
+++ b/test_gemini_api.py
@@ -1,13 +1,15 @@
-import argparse
+import os
+import sys
 from gemini_model import generate_text_with_gemini
 
 def main():
-    parser = argparse.ArgumentParser(description="Test Gemini API")
-    parser.add_argument("api_key", help="Gemini API key")
-    args = parser.parse_args()
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print("Error: GOOGLE_API_KEY environment variable not set.")
+        sys.exit(1)
 
     prompt = "Write a short story about a friendly robot."
-    generated_text = generate_text_with_gemini(api_key=args.api_key, prompt_text=prompt)
+    generated_text = generate_text_with_gemini(api_key=api_key, prompt_text=prompt)
 
     if generated_text:
         print("Gemini API test successful!")


### PR DESCRIPTION
The `test_gemini_api.py` script was failing due to an issue with API key configuration. The Gemini library expects the API key to be available primarily via the `GOOGLE_API_KEY` environment variable or by direct configuration.

This commit modifies `test_gemini_api.py` to:
- Remove command-line argument parsing for the API key.
- Fetch the API key from the `GOOGLE_API_KEY` environment variable.
- Exit with an error if the environment variable is not set.

The GitHub Actions workflow `.github/workflows/gemini_test.yml` has also been updated to:
- Set the `GOOGLE_API_KEY` environment variable (using the existing `secrets.GEMINI_API_KEY`).
- Call `test_gemini_api.py` without any command-line arguments.

These changes ensure that the test script correctly initializes the Gemini client with the necessary API key, resolving the previously encountered error.