### PR TITLE
Potential fix for code scanning alert no. 1: Artifact poisoning

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact
-          path: tmp
+          path: ${{ runner.temp }}/artifacts/
           if_no_artifact_found: ignore
 
       - name: Pythonの実行環境をセットアップ
@@ -42,5 +42,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact
-          path: tmp/
+          path: ${{ runner.temp }}/artifacts/
           retention-days: 10


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/1](https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/1)

To fix the issue, the workflow should:
1. Extract the contents of the artifact to a temporary directory (`${{ runner.temp }}/artifacts/`) instead of `tmp` to prevent overriding existing files.
2. Verify the contents of the artifact before using them. For example, ensure that the artifact contains only expected files and validate their integrity.
3. Update the workflow to use the temporary directory for subsequent steps.

The changes will involve modifying the artifact download step to use a temporary directory and ensuring that subsequent steps reference the new directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
