### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 11 * * *'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/2](https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is needed for the `actions/checkout` step to access the repository.
- The `actions/upload-artifact` and `dawidd6/action-download-artifact` steps require `actions: write` to upload and download artifacts.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
