### PR TITLE
Revert "Fix: Use GOOGLE_API_KEY environment variable for Gemini API tests (#7)

### DIFF
--- a/.github/workflows/gemini_test.yml
+++ b/.github/workflows/gemini_test.yml
@@ -28,5 +28,5 @@ jobs:
 
       - name: Test Gemini API
         env:
-          GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: python test_gemini_api.py
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: python test_gemini_api.py "${{ secrets.GEMINI_API_KEY }}"

--- a/test_gemini_api.py
+++ b/test_gemini_api.py
@@ -1,15 +1,13 @@
-import os
-import sys
+import argparse
 from gemini_model import generate_text_with_gemini
 
 def main():
-    api_key = os.environ.get("GOOGLE_API_KEY")
-    if not api_key:
-        print("Error: GOOGLE_API_KEY environment variable not set.")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="Test Gemini API")
+    parser.add_argument("api_key", help="Gemini API key")
+    args = parser.parse_args()
 
     prompt = "Write a short story about a friendly robot."
-    generated_text = generate_text_with_gemini(api_key=api_key, prompt_text=prompt)
+    generated_text = generate_text_with_gemini(api_key=args.api_key, prompt_text=prompt)
 
     if generated_text:
         print("Gemini API test successful!")


### PR DESCRIPTION
This reverts commit 428ecdd957967f405c617f1a3c86b42144dd7c08.