### PR TITLE
Potential fix for code scanning alert no. 1: Artifact poisoning

### DIFF
--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -18,12 +18,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 前回の成果物をダウンロード
-        uses: dawidd6/action-download-artifact@v11
+        run: mkdir -p ${{ runner.temp }}/artifacts/
+      - uses: dawidd6/action-download-artifact@v11
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact
           path: ${{ runner.temp }}/artifacts/
           if_no_artifact_found: ignore
+      - name: 成果物の内容を検証
+        run: |
+          if [ -f "${{ runner.temp }}/artifacts/requirements.txt" ]; then
+            echo "Error: Artifact contains a requirements.txt file, which is not allowed."
+            exit 1
+          fi
 
       - name: Pythonの実行環境をセットアップ
         uses: actions/setup-python@v5

--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -25,6 +25,7 @@ jobs:
           name: artifact
           path: ${{ runner.temp }}/artifacts/
           if_no_artifact_found: ignore
+
       - name: 成果物の内容を検証
         run: |
           if [ -f "${{ runner.temp }}/artifacts/requirements.txt" ]; then

--- a/.github/workflows/run_script.yml
+++ b/.github/workflows/run_script.yml
@@ -17,9 +17,11 @@ jobs:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4
 
-      - name: 前回の成果物をダウンロード
+      - name: フォルダ作成
         run: mkdir -p ${{ runner.temp }}/artifacts/
-      - uses: dawidd6/action-download-artifact@v11
+
+      - name: 前回の成果物をダウンロード
+        uses: dawidd6/action-download-artifact@v11
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           name: artifact


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/1](https://github.com/aegisfleet/github-trending-to-bluesky/security/code-scanning/1)

To fix the issue, we need to ensure that the contents of the downloaded artifact are treated as untrusted and cannot override critical files in the repository. The best approach is to extract the artifact to a temporary directory and verify its contents before using it. Specifically:
1. Create a temporary directory for the artifact extraction.
2. Extract the artifact to this directory.
3. Verify the contents of the artifact (e.g., ensure it does not contain files like `requirements.txt` or other critical files).
4. Use the verified contents safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
